### PR TITLE
Optimize aircraft filter checks

### DIFF
--- a/Aircraft.h
+++ b/Aircraft.h
@@ -5,6 +5,8 @@
 
 #define MODES_NON_ICAO_ADDRESS       (1<<24) // Set on addresses to indicate they are not ICAO addresses
 
+#include "AircraftDB.h"
+
 typedef struct
 {
  uint32_t            ICAO;
@@ -30,6 +32,7 @@ typedef struct
  double              Speed;
  double              VerticalRate;
  int                 SpriteImage;
+ AircraftCategory    Category;
 } TADS_B_Aircraft;
 
 //---------------------------------------------------------------------------

--- a/AircraftApi.cpp
+++ b/AircraftApi.cpp
@@ -5,6 +5,8 @@
 #include <vector>
 #include <sstream>
 #include <iostream>
+#include <algorithm>
+#include <cctype>
 #include "AircraftApi.h"
 
 //#define DEBUG_KANG
@@ -73,12 +75,13 @@ std::vector<AirportInfo> FetchAirportList() {
 
             try {
                 AirportInfo info;
-                info.code        = cells[0];
+                auto up = [](std::string s){ std::transform(s.begin(), s.end(), s.begin(), ::toupper); return s; };
+                info.code        = up(cells[0]);
                 info.name        = cells[1];
-                info.icao        = cells[2];
-                info.iata        = cells[3];
+                info.icao        = up(cells[2]);
+                info.iata        = up(cells[3]);
                 info.location    = cells[4];
-                info.countryIso2 = cells[5];
+                info.countryIso2 = up(cells[5]);
                 info.latitude    = cells[6].empty() ? 0.0 : std::stod(cells[6]);
                 info.longitude   = cells[7].empty() ? 0.0 : std::stod(cells[7]);
                 info.altitudeFeet= cells[8].empty() ? 0   : std::stoi(cells[8]);
@@ -126,11 +129,14 @@ std::vector<RouteInfo> FetchRouteList() {
 
             try {
                 RouteInfo info;
-                info.callSign     = cells[0];
-                info.code         = cells[1];
-                info.number       = cells[2];
-                info.airlineCode  = cells[3];
-                info.airportCodes = split_airport_codes(cells[4]);
+                auto up = [](std::string s){ std::transform(s.begin(), s.end(), s.begin(), ::toupper); return s; };
+                info.callSign     = up(cells[0]);
+                info.code         = up(cells[1]);
+                info.number       = up(cells[2]);
+                info.airlineCode  = up(cells[3]);
+                auto airports = split_airport_codes(cells[4]);
+                for(auto& a : airports) a = up(a);
+                info.airportCodes = airports;
                 result.push_back(info);
             } catch (const std::exception& e) {
                 std::cerr << "[Route CSV] 변환 오류: 라인 " << line_no << " [" << line << "] - " << e.what() << "\n";

--- a/DisplayGUI.cpp
+++ b/DisplayGUI.cpp
@@ -179,7 +179,8 @@ static void LoadAirlineInfo(const AnsiString& fileName)
             std::getline(ss, country, ',') &&
             std::getline(ss, name))
         {
-            code = trim(code);
+            auto up = [](std::string s){ std::transform(s.begin(), s.end(), s.begin(), ::toupper); return trim(s); };
+            code = up(code);
             country = trim(country);
             name = trim(name);
             if (!code.empty())
@@ -688,35 +689,29 @@ void TForm1::DrawDefinedAreas()
   }
 }
 
-bool TForm1::ShouldDisplayAircraft(TADS_B_Aircraft* Data, const RouteInfo* route, AircraftCategory category)
+bool TForm1::ShouldDisplayAircraft(TADS_B_Aircraft* Data, const RouteInfo* route, AircraftCategory category,
+                                   int minSpeed, int maxSpeed, int minAlt, int maxAlt,
+                                   bool airlineFilter, bool originFilter, bool destFilter)
 {
-  if ((!filterAirline.IsEmpty() || !filterOrigin.IsEmpty() || !filterDestination.IsEmpty()) && route == nullptr)
-    return false;
-
-  if (!filterAirline.IsEmpty() && route)
+  if (airlineFilter && route)
   {
-    AnsiString code = AnsiString(route->airlineCode.c_str()).UpperCase();
-    AnsiString filter = filterAirline.UpperCase();
-    if (code.SubString(1, filter.Length()) != filter)
+    AnsiString code = route->airlineCode.c_str();
+    if (code.SubString(1, filterAirline.Length()) != filterAirline)
       return false;
   }
 
-  if (!filterOrigin.IsEmpty() && route && !route->airportCodes.empty())
+  if (originFilter && route && !route->airportCodes.empty())
   {
-    if (AnsiString(route->airportCodes.front().c_str()).UpperCase() != filterOrigin.UpperCase())
+    if (AnsiString(route->airportCodes.front().c_str()) != filterOrigin)
       return false;
   }
 
-  if (!filterDestination.IsEmpty() && route && !route->airportCodes.empty())
+  if (destFilter && route && !route->airportCodes.empty())
   {
-    if (AnsiString(route->airportCodes.back().c_str()).UpperCase() != filterDestination.UpperCase())
+    if (AnsiString(route->airportCodes.back().c_str()) != filterDestination)
       return false;
   }
 
-  int minSpeed = SpeedMinTrackBar->Position;
-  int maxSpeed = SpeedMaxTrackBar->Position;
-  int minAlt = AltitudeMinTrackBar->Position;
-  int maxAlt = AltitudeMaxTrackBar->Position;
 
   if (Data->HaveSpeedAndHeading)
     if (Data->Speed < minSpeed || Data->Speed > maxSpeed)
@@ -878,6 +873,16 @@ void TForm1::BuildAircraftBatches(int &ViewableAircraft)
   ght_iterator_t iterator;
   TADS_B_Aircraft* Data;
 
+  int minSpeed = SpeedMinTrackBar->Position;
+  int maxSpeed = SpeedMaxTrackBar->Position;
+  int minAlt   = AltitudeMinTrackBar->Position;
+  int maxAlt   = AltitudeMaxTrackBar->Position;
+
+  bool airlineFilter   = !filterAirline.IsEmpty();
+  bool originFilter    = !filterOrigin.IsEmpty();
+  bool destFilter      = !filterDestination.IsEmpty();
+  bool anyRouteFilter  = airlineFilter || originFilter || destFilter;
+
   m_planeBatch.clear();
   m_lineBatch.clear();
   m_textBatch.clear();
@@ -887,24 +892,29 @@ void TForm1::BuildAircraftBatches(int &ViewableAircraft)
   {
     if (!Data->HaveLatLon) continue;
 
+    double ScrX, ScrY;
+    LatLon2XY(Data->Latitude, Data->Longitude, ScrX, ScrY);
+    if (ScrX < Map_v[0].x || ScrX > Map_v[1].x ||
+        ScrY < Map_v[0].y || ScrY > Map_v[3].y)
+      continue;
+
     const RouteInfo* route = nullptr;
-    if (!filterAirline.IsEmpty() || !filterOrigin.IsEmpty() || !filterDestination.IsEmpty())
+    if (anyRouteFilter)
     {
       auto it = callSignToRoute.find(AnsiString(Data->FlightNum).c_str());
       route = (it != callSignToRoute.end()) ? it->second : nullptr;
-      if (!IsRouteMatched(route))
+      if (!IsRouteMatched(route, airlineFilter, originFilter, destFilter))
         continue;
     }
 
-    AircraftCategory category = aircraft_get_category(Data->ICAO);
-    if (!ShouldDisplayAircraft(Data, route, category))
+    AircraftCategory category = Data->Category;
+    if (!ShouldDisplayAircraft(Data, route, category, minSpeed, maxSpeed, minAlt, maxAlt,
+                               airlineFilter, originFilter, destFilter))
       continue;
 
     ViewableAircraft++;
 
-    double ScrX, ScrY, ScrX2, ScrY2;
-    LatLon2XY(Data->Latitude, Data->Longitude, ScrX, ScrY);
-    ScrX2 = ScrX; ScrY2 = ScrY;
+    double ScrX2 = ScrX, ScrY2 = ScrY;
 
     float color[4] = {1.0f,1.0f,1.0f,1.0f};
     bool isPartOfSelectedPair = (Data->ICAO == FSelectedConflictPair.first || Data->ICAO == FSelectedConflictPair.second);
@@ -1000,7 +1010,7 @@ void TForm1::UpdateTrackHookDisplay()
       ICAOLabel->Caption=Data->HexAddr;
       if (Data->HaveFlightNum) FlightNumLabel->Caption=Data->FlightNum; else FlightNumLabel->Caption="N/A";
       std::string airline, country;
-      if (LookupAirline(AnsiString(Data->FlightNum).Trim().UpperCase().c_str(), airline, country))
+      if (LookupAirline(AnsiString(Data->FlightNum).Trim().c_str(), airline, country))
       {
         AirlineNameLabel->Caption = airline.c_str();
         AirlineCountryLabel->Caption = country.c_str();
@@ -1206,15 +1216,18 @@ void __fastcall TForm1::DrawObjects(void)
   DrawSelectedRoutes();
   DrawSelectedConflictPair();
 }
-bool TForm1::IsRouteMatched(const RouteInfo* route) const {
+bool TForm1::IsRouteMatched(const RouteInfo* route,
+                            bool airlineFilter,
+                            bool originFilter,
+                            bool destFilter) const {
     if (!route) return false;
-    if (!filterAirline.IsEmpty() && AnsiString(route->airlineCode.c_str()).UpperCase() != filterAirline.UpperCase())
+    if (airlineFilter && AnsiString(route->airlineCode.c_str()) != filterAirline)
         return false;
-    if (!filterOrigin.IsEmpty() && route->airportCodes.size() &&
-        AnsiString(route->airportCodes.front().c_str()).UpperCase() != filterOrigin.UpperCase())
+    if (originFilter && route->airportCodes.size() &&
+        AnsiString(route->airportCodes.front().c_str()) != filterOrigin)
         return false;
-    if (!filterDestination.IsEmpty() && route->airportCodes.size() &&
-        AnsiString(route->airportCodes.back().c_str()).UpperCase() != filterDestination.UpperCase())
+    if (destFilter && route->airportCodes.size() &&
+        AnsiString(route->airportCodes.back().c_str()) != filterDestination)
         return false;
     return true;
 }
@@ -2381,7 +2394,7 @@ void __fastcall TForm1::UpdateCloseControlPanel(TADS_B_Aircraft* ac, const Route
     AircraftModelLabel->Caption = GetAircraftModel(ac->ICAO);
     {
         std::string airline, country;
-        if (LookupAirline(AnsiString(ac->FlightNum).Trim().UpperCase().c_str(), airline, country))
+        if (LookupAirline(AnsiString(ac->FlightNum).Trim().c_str(), airline, country))
         {
             AirlineNameLabel->Caption = airline.c_str();
             AirlineCountryLabel->Caption = country.c_str();
@@ -2465,7 +2478,7 @@ void __fastcall TForm1::OnAircraftSelected(uint32_t icao)
 
   if (ac){
         // **배열을 AnsiString으로 변환한 뒤 처리!**
-        AnsiString flightNum = AnsiString(ac->FlightNum).Trim().UpperCase();
+        AnsiString flightNum = AnsiString(ac->FlightNum).Trim();
         auto it = callSignToRoute.find(flightNum.c_str());
         route = (it != callSignToRoute.end()) ? it->second : nullptr;
 
@@ -2492,18 +2505,18 @@ void __fastcall TForm1::OnAircraftSelected(uint32_t icao)
 
 void __fastcall TForm1::FilterAirlineEditChange(TObject *Sender)
 {
-    filterAirline = FilterAirlineEdit->Text.Trim();
+    filterAirline = FilterAirlineEdit->Text.Trim().UpperCase();
     ObjectDisplay->Repaint();
 }
 void __fastcall TForm1::FilterOriginEditChange(TObject *Sender)
 {
-    filterOrigin = FilterOriginEdit->Text.Trim();
+    filterOrigin = FilterOriginEdit->Text.Trim().UpperCase();
     LOG_DEBUG_F(LogHandler::CAT_GENERAL, "Filter origin changed: %s", filterOrigin.c_str());
     ObjectDisplay->Repaint();
 }
 void __fastcall TForm1::FilterDestinationEditChange(TObject *Sender)
 {
-    filterDestination = FilterDestinationEdit->Text.Trim();
+    filterDestination = FilterDestinationEdit->Text.Trim().UpperCase();
     ObjectDisplay->Repaint();
 }
 

--- a/DisplayGUI.h
+++ b/DisplayGUI.h
@@ -294,10 +294,12 @@ private:	// User declarations
 		void DrawMapCenterCross();
 		void DrawTemporaryArea();
 		void DrawDefinedAreas();
-		bool ShouldDisplayAircraft(TADS_B_Aircraft* Data, const RouteInfo* route, AircraftCategory category);
-		void BuildAircraftBatches(int &ViewableAircraft);
-		void RenderAircraftBatches();
-		void UpdateTrackHookDisplay();
+                bool ShouldDisplayAircraft(TADS_B_Aircraft* Data, const RouteInfo* route, AircraftCategory category,
+                                            int minSpeed, int maxSpeed, int minAlt, int maxAlt,
+                                            bool airlineFilter, bool originFilter, bool destFilter);
+                void BuildAircraftBatches(int &ViewableAircraft);
+                void RenderAircraftBatches();
+                void UpdateTrackHookDisplay();
 		void DrawCPAVisualization();
 		void DrawSelectedRoutes();
 		void DrawSelectedConflictPair();
@@ -320,7 +322,10 @@ public:		// User declarations
 	bool __fastcall LoadARTCCBoundaries(AnsiString FileName);
 	void UpdateCloseControlPanel(TADS_B_Aircraft* ac, const RouteInfo* route);
 	void OnAircraftSelected(uint32_t icao);
-	bool IsRouteMatched(const RouteInfo* route) const;
+        bool IsRouteMatched(const RouteInfo* route,
+                            bool airlineFilter,
+                            bool originFilter,
+                            bool destFilter) const;
 	void InitRouteAirportMaps(); 
 
 

--- a/Model/AircraftDataModel.cpp
+++ b/Model/AircraftDataModel.cpp
@@ -5,6 +5,7 @@
 #include "TimeFunctions.h"
 #include "RawDecoder.h"
 #include "SbsDecoder.h"
+#include "AircraftDB.h"
 #include <vector>
 
 #pragma link "HashTable\\Lib\\Win64\\Release\\HashTableLib.a"
@@ -197,6 +198,13 @@ void AircraftDataModel::ApplyUpdate(const ParsedAircraftData& parsedData, bool A
         aircraft->HaveFlightNum = true;
         strncpy(aircraft->FlightNum, parsedData.FlightNum, 9);
         aircraft->FlightNum[8] = '\0';
+        for(char* p = aircraft->FlightNum; *p; ++p) *p = toupper(*p);
+        // trim leading/trailing spaces
+        char* start = aircraft->FlightNum;
+        while(*start && isspace(*start)) ++start;
+        if(start != aircraft->FlightNum) memmove(aircraft->FlightNum, start, strlen(start)+1);
+        char* end = aircraft->FlightNum + strlen(aircraft->FlightNum) - 1;
+        while(end >= aircraft->FlightNum && isspace(*end)) { *end = '\0'; --end; }
     }
     if (parsedData.hasAltitude) {
         aircraft->HaveAltitude = true;
@@ -227,6 +235,7 @@ TADS_B_Aircraft* AircraftDataModel::FindOrCreateAircraft(unsigned int Addr, bool
         memset(aircraft, 0, sizeof(TADS_B_Aircraft)); // 모든 필드를 0으로 초기화
         aircraft->ICAO = Addr;
         snprintf(aircraft->HexAddr, sizeof(aircraft->HexAddr), "%06X", (int)Addr);
+        aircraft->Category = aircraft_get_category(Addr);
         
         // CycleImages가 체크되어 있을 때만 SpriteImage 할당
         if (ACycleImages) {


### PR DESCRIPTION
## Summary
- cache filter state for BuildAircraftBatches
- skip aircraft outside the screen
- pass filter flags to `ShouldDisplayAircraft` and `IsRouteMatched`

## Testing
- `clang++ -std=c++17 -fsyntax-only DisplayGUI.cpp` *(fails: 'vcl.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686362b2eea8832da324943c9e78393e