### PR TITLE
Optimize aircraft rendering with background thread

### DIFF
--- a/DisplayGUI.cpp
+++ b/DisplayGUI.cpp
@@ -1105,8 +1105,8 @@ void __fastcall TAircraftRenderThread::Execute()
       const RouteInfo* route = nullptr;
       if (params.airlineFilter || params.originFilter || params.destFilter)
       {
-        auto it = FOwner->callSignToRoute.find(AnsiString(Data->FlightNum).c_str());
-        route = (it != FOwner->callSignToRoute.end()) ? it->second : nullptr;
+        auto it = callSignToRoute.find(AnsiString(Data->FlightNum).c_str());
+        route = (it != callSignToRoute.end()) ? it->second : nullptr;
         if (!FOwner->IsRouteMatched(route, params.airlineFilter, params.originFilter, params.destFilter))
         {
           local[Data->ICAO] = info;

--- a/DisplayGUI.h
+++ b/DisplayGUI.h
@@ -104,7 +104,9 @@ struct RenderThreadParams {
     AnsiString filterAirline;
     AnsiString filterOrigin;
     AnsiString filterDestination;
-}; 
+};
+
+class TForm1;
 
 class TAircraftRenderThread : public TThread {
 private:

--- a/DisplayGUI.h
+++ b/DisplayGUI.h
@@ -120,6 +120,7 @@ public:
 //---------------------------------------------------------------------------
 class TForm1 : public TForm
 {
+    friend class TAircraftRenderThread;
 __published:	// IDE-managed Components
 	TMainMenu *MainMenu1;
 	TPanel *RightPanel;


### PR DESCRIPTION
## Summary
- add `AircraftRenderThread` that precomputes aircraft visibility and styling
- store results in a mutex-protected hash table
- update `BuildAircraftBatches` to consume the precomputed info
- extend GUI initialization and cleanup for the new thread

## Testing
- `ctest` *(fails: No test configuration file found)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6863e7749974832db911ed9ecd9e6c92